### PR TITLE
filter out any unexpected GET parametres.

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -119,6 +119,9 @@ class syntax_plugin_graphviz extends DokuWiki_Syntax_Plugin {
      * Return path to the rendered image on our local system
      */
     function _imgfile($data){
+        // filter out unwanted GET parametres
+        $data=array_intersect_key( $data, array( 'width' => 1, 'height' => 1, 'layout' => 1, 'align' => 1, 'version' => 1, 'md5' => 1 ));
+
         $cache  = $this->_cachename($data,'png');
 
         // create the file if needed


### PR DESCRIPTION
Fix #7. This is the changes that was proposed in #7.

This PR makes sure unexpected GET parameters are filtered out before the md5 of the requested image is computed. With this patch applied, md5 is computed exactly with the same GET parameters that were used to create it.